### PR TITLE
修复股票持有收益率显示

### DIFF
--- a/src/renderer/helpers/stock.ts
+++ b/src/renderer/helpers/stock.ts
@@ -25,8 +25,8 @@ export function CalcStock(stock: Stock.ResponseItem, codeMap: Stock.CodeMap) {
   const gszz = NP.times(gsz!, cyfe);
   const cyje = NP.times(dwjz, cyfe);
   const cbje = cbj && NP.times(cbj, cyfe);
-  const cysyl = cbj && NP.divide(NP.minus(dwjz, cbj), cbj, 0.01);
-  const cysy = cbj && NP.times(NP.minus(dwjz, cbj), cyfe);
+  const cysyl = cbj && NP.divide(NP.minus(gsz, cbj), cbj, 0.01);
+  const cysy = cbj && NP.times(NP.minus(gsz, cbj), cyfe);
   const gszzl = stock.zdf; // 估算收益率
   const gscysyl = cbj && cbj > 0 ? cysyl?.toFixed(2) : '';
 

--- a/src/renderer/helpers/stock.ts
+++ b/src/renderer/helpers/stock.ts
@@ -20,13 +20,18 @@ export function CalcStock(stock: Stock.ResponseItem, codeMap: Stock.CodeMap) {
 
   const gsz = stock.zx;
   const dwjz = stock.zs;
-  const bjz = NP.minus(gsz, dwjz) || 0;
+  // 判断 gsz 是否为有效数字（先转为字符串再比较）
+  const gszStr = String(gsz);
+  const isValidGsz = gsz !== undefined && gsz !== null && gszStr !== '' && gszStr !== 'None' && !isNaN(Number(gsz));
+  const priceForCalc = isValidGsz ? Number(gsz) : Number(dwjz);
+
+  const bjz = NP.minus(priceForCalc, dwjz) || 0;
   const jrsygz = NP.times(cyfe, bjz);
-  const gszz = NP.times(gsz!, cyfe);
+  const gszz = NP.times(priceForCalc, cyfe);
   const cyje = NP.times(dwjz, cyfe);
   const cbje = cbj && NP.times(cbj, cyfe);
-  const cysyl = cbj && NP.divide(NP.minus(gsz, cbj), cbj, 0.01);
-  const cysy = cbj && NP.times(NP.minus(gsz, cbj), cyfe);
+  const cysyl = cbj && NP.divide(NP.minus(priceForCalc, cbj), cbj, 0.01);
+  const cysy = cbj && NP.times(NP.minus(priceForCalc, cbj), cyfe);
   const gszzl = stock.zdf; // 估算收益率
   const gscysyl = cbj && cbj > 0 ? cysyl?.toFixed(2) : '';
 


### PR DESCRIPTION
修复股票持有收益率显示（使用实时价格计算持有收益率）
本地测试已解决，但打包时遇到 sqlite 错误所以是去掉了 undici 包，改为 fetch 方式，但这块我没提交改动，估计是我自己的环境问题。只提交了修复股票持有收益率的部分

普通模式：
<img width="646" height="762" alt="图片" src="https://github.com/user-attachments/assets/8cb5e253-3bd4-4747-82a8-7c0bb1538ae2" />

简洁模式：
<img width="634" height="758" alt="图片" src="https://github.com/user-attachments/assets/d0970987-326c-4797-8dca-5aa7769a9eda" />

对比之前：（使用昨日收盘价计算持有收益率）
<img width="626" height="740" alt="图片" src="https://github.com/user-attachments/assets/642d84c8-3df0-4893-bf07-306be8a31e31" />

